### PR TITLE
Updating usage of new enums

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -165,13 +165,13 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "geneweaver-core"
-version = "0.9.0a0"
+version = "0.9.0a1"
 description = "The core of the Jax-Geneweaver Python library"
 optional = false
 python-versions = ">=3.9,<4.0"
 files = [
-    {file = "geneweaver_core-0.9.0a0-py3-none-any.whl", hash = "sha256:b86a07eb8470599d75c511bdfb4255852ffb2b64d47a307711e46baa8b7463a2"},
-    {file = "geneweaver_core-0.9.0a0.tar.gz", hash = "sha256:db2ffc11ca9ce1f56a64f71140915b58fcf6fbc25314dbaf62f5b90a185bfa9a"},
+    {file = "geneweaver_core-0.9.0a1-py3-none-any.whl", hash = "sha256:7068a4e6d38c9020aa1bf3d71676c04caa0e56563d6088bace9dba0a00d2d33d"},
+    {file = "geneweaver_core-0.9.0a1.tar.gz", hash = "sha256:86b04203562e1f7b0eb328c8b12148c064c01776b1df67ddd4bdab521bb2e6f0"},
 ]
 
 [package.dependencies]
@@ -425,18 +425,18 @@ files = [
 
 [[package]]
 name = "platformdirs"
-version = "4.1.0"
+version = "4.2.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "platformdirs-4.1.0-py3-none-any.whl", hash = "sha256:11c8f37bcca40db96d8144522d925583bdb7a31f7b0e37e3ed4318400a8e2380"},
-    {file = "platformdirs-4.1.0.tar.gz", hash = "sha256:906d548203468492d432bcb294d4bc2fff751bf84971fbb2c10918cc206ee420"},
+    {file = "platformdirs-4.2.0-py3-none-any.whl", hash = "sha256:0614df2a2f37e1a662acbd8e2b25b92ccf8632929bc6d43467e17fe89c75e068"},
+    {file = "platformdirs-4.2.0.tar.gz", hash = "sha256:ef0cc731df711022c174543cb70a9b5bd22e5a9337c8624ef2c2ceb8ddad8768"},
 ]
 
 [package.extras]
-docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.1)", "sphinx-autodoc-typehints (>=1.24)"]
-test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.4)", "pytest-cov (>=4.1)", "pytest-mock (>=3.11.1)"]
+docs = ["furo (>=2023.9.10)", "proselint (>=0.13)", "sphinx (>=7.2.6)", "sphinx-autodoc-typehints (>=1.25.2)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.4.3)", "pytest-cov (>=4.1)", "pytest-mock (>=3.12)"]
 
 [[package]]
 name = "pluggy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geneweaver-db"
-version = "0.3.0a2"
+version = "0.3.0a3"
 description = "Database Interaction Services for GeneWeaver"
 authors = ["Jax Computational Sciences <cssc@jax.org>"]
 readme = "README.md"

--- a/src/geneweaver/db/geneset_value.py
+++ b/src/geneweaver/db/geneset_value.py
@@ -232,6 +232,6 @@ def by_geneset_id_and_identifier(
                   -- In case the gene doesn't have any homologs
                   h.hom_source_name IS NULL
         """,
-        {"geneset_id": geneset_id, "gdb_id": identifier.value},
+        {"geneset_id": geneset_id, "gdb_id": int(identifier)},
     )
     return cursor.fetchall()

--- a/tests/unit/gene/test_get_homolog_ids.py
+++ b/tests/unit/gene/test_get_homolog_ids.py
@@ -25,7 +25,7 @@ def test_no_optional_args(cursor, source_identifier):
             "mock query",
             {
                 "source_ids": ["1", "2"],
-                "result_genedb_id": source_identifier.value,
+                "result_genedb_id": int(source_identifier),
                 "ode_pref": "t",
             },
         )
@@ -53,8 +53,8 @@ def test_with_source_identifier(cursor, result_identifier, source_identifier):
             "mock query" * 2,
             {
                 "source_ids": ["1", "2"],
-                "result_genedb_id": result_identifier.value,
-                "source_genedb_id": source_identifier.value,
+                "result_genedb_id": int(result_identifier),
+                "source_genedb_id": int(source_identifier),
                 "ode_pref": "t",
             },
         )
@@ -82,8 +82,8 @@ def test_with_result_species(cursor, result_identifier, result_species):
             "mock query" * 2,
             {
                 "source_ids": ["1", "2"],
-                "result_genedb_id": result_identifier.value,
-                "result_sp_id": result_species.value,
+                "result_genedb_id": int(result_identifier),
+                "result_sp_id": int(result_species),
                 "ode_pref": "t",
             },
         )
@@ -107,8 +107,8 @@ def test_with_source_species(cursor, result_identifier, source_species):
             "mock query" * 2,
             {
                 "source_ids": ["1", "2"],
-                "result_genedb_id": result_identifier.value,
-                "source_sp_id": source_species.value,
+                "result_genedb_id": int(result_identifier),
+                "source_sp_id": int(source_species),
                 "ode_pref": "t",
             },
         )
@@ -135,10 +135,10 @@ def test_with_all_args(cursor, source_identifier, result_species, source_species
             "mock query" * 4,
             {
                 "source_ids": ["1", "2"],
-                "result_genedb_id": GeneIdentifier.ENSEMBLE_GENE.value,
-                "source_genedb_id": source_identifier.value,
-                "result_sp_id": result_species.value,
-                "source_sp_id": source_species.value,
+                "result_genedb_id": int(GeneIdentifier.ENSEMBLE_GENE),
+                "source_genedb_id": int(source_identifier),
+                "result_sp_id": int(result_species),
+                "source_sp_id": int(source_species),
                 "ode_pref": "t",
             },
         )


### PR DESCRIPTION
The update of `geneweaver.core` changed how enums are used to get the integer values for interaction with the database.

They changed from 
```
species.value
```

To
```
int(species)
```