### PR TITLE
Allow sqlalchemy based uses to override the connection scheme

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geneweaver-db"
-version = "0.3.0a3"
+version = "0.3.0a4"
 description = "Database Interaction Services for GeneWeaver"
 authors = ["Jax Computational Sciences <cssc@jax.org>"]
 readme = "README.md"

--- a/src/geneweaver/db/core/settings_class.py
+++ b/src/geneweaver/db/core/settings_class.py
@@ -19,6 +19,8 @@ class Settings(BaseSettings):
 
     DEBUG_MODE = False
 
+    CONNECTION_SCHEME: str = "postgresql"
+
     SERVER: str
     USERNAME: str
     PASSWORD: str = ""
@@ -40,7 +42,7 @@ class Settings(BaseSettings):
             return v
         return str(
             PostgresDsn.build(
-                scheme="postgresql",
+                scheme=values.get("CONNECTION_SCHEME"),
                 user=values.get("USERNAME"),
                 password=values.get("PASSWORD"),
                 host=values.get("SERVER"),


### PR DESCRIPTION
Adds the `CONNECTION_SCHEME` config to database settings. 

The default is the same as it used to be, so only if you don't specifically set it, the use will be the same as it was before this PR.

This is so that sqlalchemy uses can construct strings with the `postgresql+psycopg` connection scheme. 