### PR TITLE
Fixing species filter construction

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geneweaver-db"
-version = "0.3.0a11"
+version = "0.3.0a12"
 description = "Database Interaction Services for GeneWeaver"
 authors = ["Jax Computational Sciences <cssc@jax.org>"]
 readme = "README.md"

--- a/src/geneweaver/db/query/species.py
+++ b/src/geneweaver/db/query/species.py
@@ -32,17 +32,22 @@ def get(
     params = {}
     query = SQL("SELECT") + SQL(",").join(SPECIES_FIELDS) + SQL("FROM species")
 
+    filters = []
+
     if species:
-        query += SQL("WHERE sp_id = %(species_id)s")
+        filters.append(SQL("sp_id = %(species_id)s"))
         params["species_id"] = int(species)
 
     if taxonomic_id:
-        query += SQL("WHERE sp_taxid = %(taxonomic_id)s")
+        filters.append(SQL("sp_taxid = %(taxonomic_id)s"))
         params["taxonomic_id"] = taxonomic_id
 
     if reference_gene_db_id:
-        query += SQL("WHERE sp_ref_gdb_id = %(reference_gene_db_id)s")
+        filters.append(SQL("sp_ref_gdb_id = %(reference_gene_db_id)s"))
         params["reference_gene_db_id"] = int(reference_gene_db_id)
+
+    if len(filters) > 0:
+        query += SQL("WHERE") + SQL("AND").join(filters)
 
     query = query.join(" ")
 


### PR DESCRIPTION
This PR fixes an error @francastell was seeing when using this method in the API.

```
psycopg.errors.SyntaxError: syntax error at or near “WHERE”
LINE 1: ...gene_identifier” FROM species WHERE sp_taxid = $1 WHERE sp_r...
```

As an added bonus, it also makes the implementation more in-line with the rest of the query construction methods.