### PR TITLE
Return initialized User schemas and a bugfix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "geneweaver-db"
-version = "0.6.0a0"
+version = "0.6.0a1"
 description = "Database Interaction Services for GeneWeaver"
 authors = ["Jax Computational Sciences <cssc@jax.org>"]
 readme = "README.md"

--- a/src/geneweaver/db/aio/user.py
+++ b/src/geneweaver/db/aio/user.py
@@ -7,14 +7,26 @@ The functions that return one or more entire user records are:
 - by_email
 """
 
-from typing import List
+from typing import Optional
 
+from geneweaver.core.schema.user import User
 from geneweaver.db.query import user
 from geneweaver.db.utils import temp_override_row_factory
 from psycopg import AsyncCursor, rows
 
 
-async def by_api_key(cursor: AsyncCursor, api_key: str) -> List:
+async def __fetch_and_return_user(cursor: AsyncCursor) -> Optional[User]:
+    """Fetch and return a user from the cursor.
+
+    :param cursor: The database cursor.
+
+    :return: The user if found, otherwise None.
+    """
+    result = await cursor.fetchone()
+    return User(**result) if result else None
+
+
+async def by_api_key(cursor: AsyncCursor, api_key: str) -> Optional[User]:
     """Get user info by api key.
 
     :param cursor: The database cursor.
@@ -23,10 +35,10 @@ async def by_api_key(cursor: AsyncCursor, api_key: str) -> List:
     :return: list of results using `.fetchall()`
     """
     await cursor.execute(*user.by_api_key(api_key))
-    return await cursor.fetchall()
+    return await __fetch_and_return_user(cursor)
 
 
-async def by_sso_id(cursor: AsyncCursor, sso_id: str) -> List:
+async def by_sso_id(cursor: AsyncCursor, sso_id: str) -> Optional[User]:
     """Get user info by sso id.
 
     :param cursor: The database cursor.
@@ -35,10 +47,12 @@ async def by_sso_id(cursor: AsyncCursor, sso_id: str) -> List:
     :return: list of results using `.fetchall()`
     """
     await cursor.execute(*user.by_sso_id(sso_id))
-    return await cursor.fetchall()
+    return await __fetch_and_return_user(cursor)
 
 
-async def by_sso_id_and_email(cursor: AsyncCursor, sso_id: str, email: str) -> List:
+async def by_sso_id_and_email(
+    cursor: AsyncCursor, sso_id: str, email: str
+) -> Optional[User]:
     """Get user info by sso id and email.
 
     :param cursor: The database cursor.
@@ -48,10 +62,10 @@ async def by_sso_id_and_email(cursor: AsyncCursor, sso_id: str, email: str) -> L
     :return: list of results using `.fetchall()`
     """
     await cursor.execute(*user.by_sso_id_and_email(sso_id, email))
-    return await cursor.fetchall()
+    return await __fetch_and_return_user(cursor)
 
 
-async def by_user_id(cursor: AsyncCursor, user_id: int) -> List:
+async def by_user_id(cursor: AsyncCursor, user_id: int) -> Optional[User]:
     """Get user info by user id.
 
     :param cursor: The database cursor.
@@ -60,10 +74,10 @@ async def by_user_id(cursor: AsyncCursor, user_id: int) -> List:
     :return: list of results using `.fetchall()`
     """
     await cursor.execute(*user.by_id(user_id))
-    return await cursor.fetchall()
+    return await __fetch_and_return_user(cursor)
 
 
-async def by_email(cursor: AsyncCursor, email: str) -> List:
+async def by_email(cursor: AsyncCursor, email: str) -> Optional[User]:
     """Get user info by email.
 
     :param cursor: The database cursor.
@@ -72,7 +86,7 @@ async def by_email(cursor: AsyncCursor, email: str) -> List:
     :return: list of results using `.fetchall()`
     """
     await cursor.execute(*user.by_email(email))
-    return await cursor.fetchall()
+    return await __fetch_and_return_user(cursor)
 
 
 @temp_override_row_factory(rows.tuple_row)

--- a/src/geneweaver/db/query/user.py
+++ b/src/geneweaver/db/query/user.py
@@ -8,7 +8,7 @@ from psycopg.sql import SQL, Composed
 USER_FIELD_MAP = {
     "usr_id": "id",
     "usr_email": "email",
-    "user_prefs": "prefs",
+    "usr_prefs": "prefs",
     "is_guest": "is_guest",
     "usr_first_name": "first_name",
     "usr_last_name": "last_name",

--- a/src/geneweaver/db/user.py
+++ b/src/geneweaver/db/user.py
@@ -19,8 +19,9 @@ The functions that return a single value from a user record are:
 - user_id_from_sso_id
 """
 
-from typing import List, Optional
+from typing import Optional
 
+from geneweaver.core.schema.user import User
 from geneweaver.db.query import user
 from geneweaver.db.utils import temp_override_row_factory
 from psycopg import Cursor, rows
@@ -60,7 +61,18 @@ def user_id_from_sso_id(cursor: Cursor, sso_id: str) -> Optional[int]:
     return result[0] if result else None
 
 
-def by_api_key(cursor: Cursor, api_key: str) -> List:
+def __fetch_and_return_user(cursor: Cursor) -> Optional[User]:
+    """Fetch and return a user from the cursor.
+
+    :param cursor: The database cursor.
+
+    :return: The user if found, otherwise None.
+    """
+    result = cursor.fetchone()
+    return User(**result) if result else None
+
+
+def by_api_key(cursor: Cursor, api_key: str) -> Optional[User]:
     """Get user info by api key.
 
     :param cursor: The database cursor.
@@ -69,10 +81,10 @@ def by_api_key(cursor: Cursor, api_key: str) -> List:
     :return: list of results using `.fetchall()`
     """
     cursor.execute(*user.by_api_key(api_key))
-    return cursor.fetchall()
+    return __fetch_and_return_user(cursor)
 
 
-def by_sso_id(cursor: Cursor, sso_id: str) -> List:
+def by_sso_id(cursor: Cursor, sso_id: str) -> Optional[User]:
     """Get user info by sso id.
 
     :param cursor: The database cursor.
@@ -81,10 +93,10 @@ def by_sso_id(cursor: Cursor, sso_id: str) -> List:
     :return: list of results using `.fetchall()`
     """
     cursor.execute(*user.by_sso_id(sso_id))
-    return cursor.fetchall()
+    return __fetch_and_return_user(cursor)
 
 
-def by_sso_id_and_email(cursor: Cursor, sso_id: str, email: str) -> List:
+def by_sso_id_and_email(cursor: Cursor, sso_id: str, email: str) -> Optional[User]:
     """Get user info by sso id and email.
 
     :param cursor: The database cursor.
@@ -94,10 +106,10 @@ def by_sso_id_and_email(cursor: Cursor, sso_id: str, email: str) -> List:
     :return: list of results using `.fetchall()`
     """
     cursor.execute(*user.by_sso_id_and_email(sso_id, email))
-    return cursor.fetchall()
+    return __fetch_and_return_user(cursor)
 
 
-def by_user_id(cursor: Cursor, user_id: int) -> List:
+def by_user_id(cursor: Cursor, user_id: int) -> Optional[User]:
     """Get user info by user id.
 
     :param cursor: The database cursor.
@@ -106,10 +118,10 @@ def by_user_id(cursor: Cursor, user_id: int) -> List:
     :return: list of results using `.fetchall()`
     """
     cursor.execute(*user.by_id(user_id))
-    return cursor.fetchall()
+    return __fetch_and_return_user(cursor)
 
 
-def by_email(cursor: Cursor, email: str) -> List:
+def by_email(cursor: Cursor, email: str) -> Optional[User]:
     """Get user info by email.
 
     :param cursor: The database cursor.
@@ -118,7 +130,7 @@ def by_email(cursor: Cursor, email: str) -> List:
     :return: list of results using `.fetchall()`
     """
     cursor.execute(*user.by_email(email))
-    return cursor.fetchall()
+    return __fetch_and_return_user(cursor)
 
 
 @temp_override_row_factory(rows.tuple_row)

--- a/tests/unit/user/test_by_api_key.py
+++ b/tests/unit/user/test_by_api_key.py
@@ -1,6 +1,6 @@
 """Test for the user.by_api_key function."""
 
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 from geneweaver.db.user import by_api_key
@@ -8,14 +8,15 @@ from geneweaver.db.user import by_api_key
 from .const import MOCK_USER_DATA
 
 
+@patch("geneweaver.db.user.User", dict)
 @pytest.mark.parametrize(
     ("api_key", "expected_result"),
-    [(item["apikey"], [item]) for item in MOCK_USER_DATA],
+    [(item["apikey"], item) for item in MOCK_USER_DATA],
 )
 def test_by_api_key(api_key, expected_result):
     """Test the user by api key function with a mock cursor."""
     cursor = Mock()
-    cursor.fetchall.return_value = expected_result
+    cursor.fetchone.return_value = expected_result
     result = by_api_key(cursor, api_key)
     assert result == expected_result
     assert cursor.execute.call_count == 1
@@ -29,15 +30,15 @@ def test_by_api_key_execute_raises_error(all_psycopg_errors):
         by_api_key(cursor, "1")
 
     assert cursor.execute.call_count == 1
-    assert cursor.fetchall.call_count == 0
+    assert cursor.fetchone.call_count == 0
 
 
-def test_by_api_key_fetchall_raises_error(all_psycopg_errors):
-    """Test that the function raises an error when cursor.fetchall raises an error."""
+def test_by_api_key_fetchone_raises_error(all_psycopg_errors):
+    """Test that the function raises an error when cursor.fetchone raises an error."""
     cursor = Mock()
-    cursor.fetchall.side_effect = all_psycopg_errors("Error message")
+    cursor.fetchone.side_effect = all_psycopg_errors("Error message")
     with pytest.raises(all_psycopg_errors, match="Error message"):
         by_api_key(cursor, "1")
 
     assert cursor.execute.call_count == 1
-    assert cursor.fetchall.call_count == 1
+    assert cursor.fetchone.call_count == 1

--- a/tests/unit/user/test_by_email.py
+++ b/tests/unit/user/test_by_email.py
@@ -1,6 +1,6 @@
 """Test for the user.by_email function."""
 
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 from geneweaver.db.user import by_email
@@ -8,14 +8,15 @@ from geneweaver.db.user import by_email
 from .const import MOCK_USER_DATA
 
 
+@patch("geneweaver.db.user.User", dict)
 @pytest.mark.parametrize(
     ("email", "expected_result"),
-    [(item["usr_email"], [item]) for item in MOCK_USER_DATA],
+    [(item["usr_email"], item) for item in MOCK_USER_DATA],
 )
 def test_by_email(email, expected_result):
     """Test the user by ap key function with a mock cursor."""
     cursor = Mock()
-    cursor.fetchall.return_value = expected_result
+    cursor.fetchone.return_value = expected_result
     result = by_email(cursor, email)
     assert result == expected_result
     assert cursor.execute.call_count == 1
@@ -29,15 +30,15 @@ def test_by_email_execute_raises_error(all_psycopg_errors):
         by_email(cursor, "john.doe@jax.org")
 
     assert cursor.execute.call_count == 1
-    assert cursor.fetchall.call_count == 0
+    assert cursor.fetchone.call_count == 0
 
 
-def test_by_email_fetchall_raises_error(all_psycopg_errors):
-    """Test that the function raises an error when cursor.fetchall raises an error."""
+def test_by_email_fetchone_raises_error(all_psycopg_errors):
+    """Test that the function raises an error when cursor.fetchone raises an error."""
     cursor = Mock()
-    cursor.fetchall.side_effect = all_psycopg_errors("Error message")
+    cursor.fetchone.side_effect = all_psycopg_errors("Error message")
     with pytest.raises(all_psycopg_errors, match="Error message"):
         by_email(cursor, "john.doe@jax.org")
 
     assert cursor.execute.call_count == 1
-    assert cursor.fetchall.call_count == 1
+    assert cursor.fetchone.call_count == 1

--- a/tests/unit/user/test_by_sso_id.py
+++ b/tests/unit/user/test_by_sso_id.py
@@ -1,6 +1,6 @@
 """Test for the user.by_sso_id function."""
 
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 from geneweaver.db.user import by_sso_id
@@ -8,14 +8,15 @@ from geneweaver.db.user import by_sso_id
 from .const import MOCK_USER_DATA
 
 
+@patch("geneweaver.db.user.User", dict)
 @pytest.mark.parametrize(
     ("sso_id", "expected_result"),
-    [(item["usr_sso_id"], [item]) for item in MOCK_USER_DATA],
+    [(item["usr_sso_id"], item) for item in MOCK_USER_DATA],
 )
 def test_by_api_key(sso_id, expected_result):
     """Test the user by sso id function with a mock cursor."""
     cursor = Mock()
-    cursor.fetchall.return_value = expected_result
+    cursor.fetchone.return_value = expected_result
     result = by_sso_id(cursor, sso_id)
     assert result == expected_result
     assert cursor.execute.call_count == 1
@@ -29,15 +30,15 @@ def test_by_sso_id_execute_raises_error(all_psycopg_errors):
         by_sso_id(cursor, "sso_id")
 
     assert cursor.execute.call_count == 1
-    assert cursor.fetchall.call_count == 0
+    assert cursor.fetchone.call_count == 0
 
 
-def test_by_sso_id_fetchall_raises_error(all_psycopg_errors):
-    """Test that the function raises an error when cursor.fetchall raises an error."""
+def test_by_sso_id_fetchone_raises_error(all_psycopg_errors):
+    """Test that the function raises an error when cursor.fetchone raises an error."""
     cursor = Mock()
-    cursor.fetchall.side_effect = all_psycopg_errors("Error message")
+    cursor.fetchone.side_effect = all_psycopg_errors("Error message")
     with pytest.raises(all_psycopg_errors, match="Error message"):
         by_sso_id(cursor, "sso_id")
 
     assert cursor.execute.call_count == 1
-    assert cursor.fetchall.call_count == 1
+    assert cursor.fetchone.call_count == 1

--- a/tests/unit/user/test_by_sso_id_and_email.py
+++ b/tests/unit/user/test_by_sso_id_and_email.py
@@ -1,6 +1,6 @@
 """Test for the user.by_sso_id function."""
 
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 from geneweaver.db.user import by_sso_id_and_email
@@ -8,17 +8,18 @@ from geneweaver.db.user import by_sso_id_and_email
 from .const import MOCK_USER_DATA
 
 
+@patch("geneweaver.db.user.User", dict)
 @pytest.mark.parametrize(
     "email", ["email@email.com", "email@jax.org", "e.mail@jax.org"]
 )
 @pytest.mark.parametrize(
     ("sso_id", "expected_result"),
-    [(item["usr_sso_id"], [item]) for item in MOCK_USER_DATA],
+    [(item["usr_sso_id"], item) for item in MOCK_USER_DATA],
 )
 def test_by_api_key(sso_id, expected_result, email):
     """Test the user by sso id function with a mock cursor."""
     cursor = Mock()
-    cursor.fetchall.return_value = expected_result
+    cursor.fetchone.return_value = expected_result
     result = by_sso_id_and_email(cursor, sso_id, email)
     assert result == expected_result
     assert cursor.execute.call_count == 1
@@ -32,15 +33,15 @@ def test_by_sso_id_execute_raises_error(all_psycopg_errors):
         by_sso_id_and_email(cursor, "sso_id", "email@email.com")
 
     assert cursor.execute.call_count == 1
-    assert cursor.fetchall.call_count == 0
+    assert cursor.fetchone.call_count == 0
 
 
-def test_by_sso_id_fetchall_raises_error(all_psycopg_errors):
-    """Test that the function raises an error when cursor.fetchall raises an error."""
+def test_by_sso_id_fetchone_raises_error(all_psycopg_errors):
+    """Test that the function raises an error when cursor.fetchone raises an error."""
     cursor = Mock()
-    cursor.fetchall.side_effect = all_psycopg_errors("Error message")
+    cursor.fetchone.side_effect = all_psycopg_errors("Error message")
     with pytest.raises(all_psycopg_errors, match="Error message"):
         by_sso_id_and_email(cursor, "sso_id", "email@email.com")
 
     assert cursor.execute.call_count == 1
-    assert cursor.fetchall.call_count == 1
+    assert cursor.fetchone.call_count == 1

--- a/tests/unit/user/test_by_user_id.py
+++ b/tests/unit/user/test_by_user_id.py
@@ -1,6 +1,6 @@
 """Test for the user.by_user_id function."""
 
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 from geneweaver.db.user import by_user_id
@@ -8,14 +8,15 @@ from geneweaver.db.user import by_user_id
 from .const import MOCK_USER_DATA
 
 
+@patch("geneweaver.db.user.User", dict)
 @pytest.mark.parametrize(
     ("user_id", "expected_result"),
-    [(item["usr_id"], [item]) for item in MOCK_USER_DATA],
+    [(item["usr_id"], item) for item in MOCK_USER_DATA],
 )
 def test_by_api_key(user_id, expected_result):
     """Test the user by user id function with a mock cursor."""
     cursor = Mock()
-    cursor.fetchall.return_value = expected_result
+    cursor.fetchone.return_value = expected_result
     result = by_user_id(cursor, user_id)
     assert result == expected_result
     assert cursor.execute.call_count == 1
@@ -29,15 +30,15 @@ def test_by_user_id_execute_raises_error(all_psycopg_errors):
         by_user_id(cursor, 1)
 
     assert cursor.execute.call_count == 1
-    assert cursor.fetchall.call_count == 0
+    assert cursor.fetchone.call_count == 0
 
 
-def test_by_user_id_fetchall_raises_error(all_psycopg_errors):
-    """Test that the function raises an error when cursor.fetchall raises an error."""
+def test_by_user_id_fetchone_raises_error(all_psycopg_errors):
+    """Test that the function raises an error when cursor.fetchone raises an error."""
     cursor = Mock()
-    cursor.fetchall.side_effect = all_psycopg_errors("Error message")
+    cursor.fetchone.side_effect = all_psycopg_errors("Error message")
     with pytest.raises(all_psycopg_errors, match="Error message"):
         by_user_id(cursor, 1)
 
     assert cursor.execute.call_count == 1
-    assert cursor.fetchall.call_count == 1
+    assert cursor.fetchone.call_count == 1


### PR DESCRIPTION
This PR extends the previous PR by initializing the User object after query execution. This was done now since the previous pre-release already changed the returned data from these functions.

It also fixes a bug in the previous PR that used an incorrect column name.